### PR TITLE
fix a bug with dropdown list transition

### DIFF
--- a/src/sass/layouts/_filter.scss
+++ b/src/sass/layouts/_filter.scss
@@ -133,7 +133,7 @@
   opacity: 1;
   pointer-events: all;
   visibility: visible;
-  transform: translateY(0) scaleY(1);
+  transform: translateY(0.01%) scaleY(1);
 }
 
 .dropdown-list.isOpen + .dropdown-btn {


### PR DESCRIPTION
Dropdown list transition didn't work because Parcel combined 2 css properties into 1 which doesn't suppor transitions. Now this problem is solved.